### PR TITLE
Bump multi_json for compatibility with uglifier in rails 3.1 apps

### DIFF
--- a/assistly.gemspec
+++ b/assistly.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday', '~> 0.6.0')
   s.add_runtime_dependency('faraday_middleware', '~> 0.6.3')
   s.add_runtime_dependency('jruby-openssl', '~> 0.7.2') if RUBY_PLATFORM == 'java'
-  s.add_runtime_dependency('multi_json', '~> 0.0.5')
+  s.add_runtime_dependency('multi_json', '~> 1.0.3')
   s.add_runtime_dependency('multi_xml', '~> 0.2.0')
   s.add_runtime_dependency('rash', '~> 0.3.0')
   s.add_runtime_dependency('simple_oauth', '~> 0.1.4')


### PR DESCRIPTION
Rails 3.1 now uses uglifier by default, which depends on multi_json 1.0.3. This gem is currently specified with multi_json ~> 0.0.5, so this results in a compatibility problem when using this gem in an rails app.

Bumping multi_json to 1.0.3 solves this, tests pass, and I haven't been able to find anything wrong in manual testing as a result of the change.
