### PR TITLE
Set hashie gem explicitly to 1.2.0 for Omniauth version 1+ compatibility

### DIFF
--- a/assistly.gemspec
+++ b/assistly.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('webmock', '~> 1.6')
   s.add_development_dependency('yard', '~> 0.6')
   s.add_development_dependency('ZenTest', '~> 4.5')
-  s.add_runtime_dependency('hashie', '~> 1.2.0')
+  s.add_runtime_dependency('hashie', '= 1.2.0')
   s.add_runtime_dependency('faraday', '~> 0.7.0')
   s.add_runtime_dependency('faraday_middleware', '~> 0.7.0')
   s.add_runtime_dependency('jruby-openssl', '~> 0.7.2') if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
Allows for Omniauth version 1+ compatibility
