### PR TITLE
Update Faraday Middleware Dependency Version

### DIFF
--- a/desk.gemspec
+++ b/desk.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('json', '~> 1.7')  if RUBY_VERSION < '1.9'
   s.add_runtime_dependency('hashie', '~> 1.2.0')
   s.add_runtime_dependency('faraday', '~> 0.8.0')
-  s.add_runtime_dependency('faraday_middleware', '~> 0.8.0')
+  s.add_runtime_dependency('faraday_middleware', '~> 0.9.0')
   s.add_runtime_dependency('jruby-openssl', '~> 0.7.2') if RUBY_PLATFORM == 'java'
   s.add_runtime_dependency('multi_json', '~> 1.6')
   s.add_runtime_dependency('multi_xml', '~> 0.5')


### PR DESCRIPTION
## Updates
- `'faraday_middleware'` dependency updated to version `~>0.9.0`
- Tests passed after updating version.
