### PR TITLE
Update simple_oauth to latest version

### DIFF
--- a/desk.gemspec
+++ b/desk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('multi_json', '~> 1.6')
   s.add_runtime_dependency('multi_xml', '~> 0.5')
   s.add_runtime_dependency('rash', '~> 0.3.1')
-  s.add_runtime_dependency('simple_oauth', '~> 0.1.4')
+  s.add_runtime_dependency('simple_oauth', '~> 0.2.0')
   s.add_runtime_dependency('pony', '~> 1.1')
   s.authors = ["Chris Warren"]
   s.description = %q{A Ruby wrapper for the Desk.com REST API}


### PR DESCRIPTION
I'm cleaning up our project dependencies and wanted to switch to desk master.
This PR will fix version conflicts we have with twitter gem.

Please check out: https://github.com/zencoder/desk/issues/21.

Thanks.
