### PR TITLE
Allow for 2.x versions of hashie gem dependency

### DIFF
--- a/desk.gemspec
+++ b/desk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('webmock', '~> 1.6')
   s.add_development_dependency('yard', '~> 0.6')
   s.add_runtime_dependency('json', '~> 1.7')  if RUBY_VERSION < '1.9'
-  s.add_runtime_dependency('hashie', '~> 2.0.0')
+  s.add_runtime_dependency('hashie', '~> 2.0')
   s.add_runtime_dependency('faraday', '~> 0.9.0')
   s.add_runtime_dependency('faraday_middleware', '~> 0.9.0')
   s.add_runtime_dependency('jruby-openssl', '~> 0.7.2') if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
Bumped to hashie ~> 2.0, tests pass.  Also smoke tests with simple real-world calls also seem to work, not thoroughly tested in-application yet.

Also needed to bump rash gem version which has been updated for hashie 2.x compatibility.
