### PR TITLE
Raise namespaced errors for other non-200 responses from Desk API

### DIFF
--- a/lib/desk/error.rb
+++ b/lib/desk/error.rb
@@ -41,15 +41,24 @@ module Desk
   # Raised when Desk returns the HTTP status code 406
   class NotAcceptable < Error; end
 
+  # Raised when Desk returns the HTTP status code 409
+  class Conflict < Error; end
+
+  # Raised when Desk returns the HTTP status code 422
+  class Unprocessable < Error; end
+
   # Raised when Desk returns the HTTP status code 429
   # Called EnhanceYourCalm because TooManyRequests is taken (see below)
   class EnhanceYourCalm < Error; end
-  
+
   # Raised when Desk max_requests is reached and use_max_requests is set to true
   class TooManyRequests < StandardError; end
 
   # Raised when Desk returns the HTTP status code 500
   class InternalServerError < Error; end
+
+  # Raised when Desk returns the HTTP status code 501
+  class NotImplemented < Error; end
 
   # Raised when Desk returns the HTTP status code 502
   class BadGateway < Error; end

--- a/lib/faraday/response/raise_http_4xx.rb
+++ b/lib/faraday/response/raise_http_4xx.rb
@@ -16,6 +16,10 @@ module Faraday
         raise Desk::NotFound.new(error_message(env), env[:response_headers])
       when 406
         raise Desk::NotAcceptable.new(error_message(env), env[:response_headers])
+      when 409
+        raise Desk::Conflict.new(error_message(env), env[:response_headers])
+      when 422
+        raise Desk::Unprocessable.new(error_message(env), env[:response_headers])
       when 429
         raise Desk::EnhanceYourCalm.new(error_message(env), env[:response_headers])
       end

--- a/lib/faraday/response/raise_http_5xx.rb
+++ b/lib/faraday/response/raise_http_5xx.rb
@@ -8,6 +8,8 @@ module Faraday
       case env[:status].to_i
       when 500
         raise Desk::InternalServerError.new(error_message(env, "Something is technically wrong."), env[:response_headers])
+      when 501
+        raise Desk::NotImplemented.new(error_message(env, "Not implemented."), env[:response_headers])
       when 502
         raise Desk::BadGateway.new(error_message(env, "Desk.com is down or being upgraded."), env[:response_headers])
       when 503

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -11,8 +11,11 @@ describe Faraday::Response do
     403 => Desk::Forbidden,
     404 => Desk::NotFound,
     406 => Desk::NotAcceptable,
+    409 => Desk::Conflict,
+    422 => Desk::Unprocessable,
     429 => Desk::EnhanceYourCalm,
     500 => Desk::InternalServerError,
+    501 => Desk::NotImplemented,
     502 => Desk::BadGateway,
     503 => Desk::ServiceUnavailable,
   }.each do |status, exception|


### PR DESCRIPTION
Add specific error classes and #raise clauses for other non-200 codes that can be returned from the Desk API.

Closes #45 
