### PR TITLE
Add logger key to configuration hash in api_spec

### DIFF
--- a/spec/desk/api_spec.rb
+++ b/spec/desk/api_spec.rb
@@ -42,7 +42,8 @@ describe Desk::API do
           :support_email => 'help@zencoder.com',
           :use_max_requests => true,
           :user_agent => 'Custom User Agent',
-          :version => "amazing"
+          :version => "amazing",
+          :logger => double('logger')
         }
       end
 


### PR DESCRIPTION
Currently master is broken. This commit should fix the failing specs.