### PR TITLE
Check correct Hashie for key when returning Deash results.

### DIFF
--- a/lib/desk/deash.rb
+++ b/lib/desk/deash.rb
@@ -93,7 +93,7 @@ module Hashie
     end
 
     def results
-      self._embedded['entries'] if key?('_embedded') && self._embedded.key?('entries')
+      self._embedded['entries'] if self.raw.key?('_embedded') && self._embedded.key?('entries')
     end
 
   end


### PR DESCRIPTION
Noticed that the `results` method didn't return anything. My ruby is a bit rusty (dusty? :crystal_ball: ) but I think this is an o.k solution.