### PR TITLE
Basic authentication and custom domain name support

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -389,6 +389,19 @@ Usage Examples
     # Show the daily system message
     Desk.system_message
 
+    # Basic authentication with username and password; not recommended
+
+    Desk.configure do |config|
+      config.support_email = "help@example.com"
+      config.subdomain = YOUR_DESK_SUBDOMAIN
+      config.consumer_key = YOUR_CONSUMER_KEY
+      config.consumer_secret = YOUR_CONSUMER_SECRET
+      config.auth_method = Desk::Authentication::Methods:BASIC
+      config.basic_auth_username = YOUR_USERNAME
+      config.basic_auth_password = YOUR_PASSWORD
+    end
+
+
 Contributing
 ------------
 In the spirit of [free software](http://www.fsf.org/licensing/essays/free-sw.html), **everyone** is encouraged to help improve this project.

--- a/lib/desk/api.rb
+++ b/lib/desk/api.rb
@@ -18,7 +18,7 @@ module Desk
     end
 
     def endpoint
-      "https://#{self.subdomain}.desk.com"+api_path
+      "https://#{self.subdomain}.#{self.domain}"+api_path
     end
 
     def api_path

--- a/lib/desk/authentication.rb
+++ b/lib/desk/authentication.rb
@@ -1,17 +1,47 @@
 module Desk
   # @private
   module Authentication
+    module Methods
+      OAUTH = "oauth"
+      BASIC = "basic"
+      ALL = [
+        OAUTH,
+        BASIC,
+      ]
+    end
+
     private
 
     # Authentication hash
     #
     # @return [Hash]
     def authentication
+      if auth_method == Methods::BASIC
+        basic_authentication
+      else
+        oauth_authentication
+      end
+    end
+
+    # Authentication hash for OAUTH connections
+    #
+    # @return [Hash]
+    def oauth_authentication
       {
         :consumer_key => consumer_key,
         :consumer_secret => consumer_secret,
         :token => oauth_token,
         :token_secret => oauth_token_secret
+      }
+    end
+
+    # Authentication hash for Basic auth connections
+    #
+    # @return [Hash]
+    def basic_authentication
+      {
+        :username => basic_auth_username,
+        :password => basic_auth_password
       }
     end
 

--- a/lib/desk/client/case.rb
+++ b/lib/desk/client/case.rb
@@ -65,7 +65,7 @@ module Desk
       end
 
       def case_url(case_id)
-        "https://#{subdomain}.desk.com/agent/case/#{case_id}"
+        "https://#{subdomain}.#{domain}/agent/case/#{case_id}"
       end
     end
   end

--- a/lib/desk/configuration.rb
+++ b/lib/desk/configuration.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'desk/version'
+require 'desk/authentication'
 
 module Desk
   # Defines constants and methods related to configuration
@@ -7,6 +8,9 @@ module Desk
     # An array of valid keys in the options hash when configuring a {Twitter::API}
     VALID_OPTIONS_KEYS = [
       :adapter,
+      :auth_method,
+      :basic_auth_username,
+      :basic_auth_password,
       :consumer_key,
       :consumer_secret,
       :domain,
@@ -32,6 +36,15 @@ module Desk
     #
     # @note The default faraday adapter is Net::HTTP.
     DEFAULT_ADAPTER = Faraday.default_adapter
+
+    # By default, OAUTH is selected
+    DEFAULT_AUTH_METHOD = Desk::Authentication::Methods::OAUTH
+
+    # By default, don't set a username
+    DEFAULT_BASIC_AUTH_USERNAME = nil
+
+    # By default, don't set a password
+    DEFAULT_BASIC_AUTH_PASSWORD = nil
 
     # By default, use the desk.com hosted domain
     DEFAULT_DOMAIN = "desk.com"
@@ -79,6 +92,7 @@ module Desk
     # By default, don't set a support email address
     DEFAULT_SUPPORT_EMAIL = nil
 
+    attr_reader :DEFAULT_ADAPTER
     # @private
     attr_accessor *VALID_OPTIONS_KEYS
 
@@ -103,6 +117,14 @@ module Desk
 
     def adapter=(val)
       Thread.current[:adapter] = val
+    end
+
+    def auth_method
+      Thread.current[:auth_method] ||= DEFAULT_ADAPTER
+    end
+
+    def auth_method=(val)
+      Thread.current[:auth_method] = val
     end
 
     def consumer_key
@@ -220,6 +242,9 @@ module Desk
     # Reset all configuration options to defaults
     def reset
       self.adapter            = DEFAULT_ADAPTER
+      self.auth_method        = DEFAULT_AUTH_METHOD
+      self.basic_auth_username= DEFAULT_BASIC_AUTH_USERNAME
+      self.basic_auth_password= DEFAULT_BASIC_AUTH_PASSWORD
       self.consumer_key       = DEFAULT_CONSUMER_KEY
       self.consumer_secret    = DEFAULT_CONSUMER_SECRET
       self.domain             = DEFAULT_DOMAIN

--- a/lib/desk/configuration.rb
+++ b/lib/desk/configuration.rb
@@ -9,6 +9,7 @@ module Desk
       :adapter,
       :consumer_key,
       :consumer_secret,
+      :domain,
       :format,
       :logger,
       :max_requests,
@@ -31,6 +32,9 @@ module Desk
     #
     # @note The default faraday adapter is Net::HTTP.
     DEFAULT_ADAPTER = Faraday.default_adapter
+
+    # By default, use the desk.com hosted domain
+    DEFAULT_DOMAIN = "desk.com"
 
     # By default, don't set an application key
     DEFAULT_CONSUMER_KEY = nil
@@ -115,6 +119,14 @@ module Desk
 
     def consumer_secret=(val)
       Thread.current[:consumer_secret] = val
+    end
+
+    def domain
+      Thread.current[:domain] ||= DEFAULT_DOMAIN
+    end
+
+    def domain=(val)
+      Thread.current[:domain] = val
     end
 
     def format
@@ -210,6 +222,7 @@ module Desk
       self.adapter            = DEFAULT_ADAPTER
       self.consumer_key       = DEFAULT_CONSUMER_KEY
       self.consumer_secret    = DEFAULT_CONSUMER_SECRET
+      self.domain             = DEFAULT_DOMAIN
       self.format             = DEFAULT_FORMAT
       self.logger             = DEFAULT_LOGGER
       self.max_requests       = DEFAULT_MAX_REQUESTS

--- a/lib/desk/connection.rb
+++ b/lib/desk/connection.rb
@@ -19,7 +19,13 @@ module Desk
 
       Faraday.new(options) do |builder|
         builder.use Faraday::Request::MultipartWithFile
-        builder.use Faraday::Request::OAuth, authentication if authenticated?
+        if authenticated?
+          if auth_method == Desk::Authentication::Methods::BASIC
+            builder.use Faraday::Request::BasicAuthentication,basic_auth_username, basic_auth_password
+          else
+            builder.use Faraday::Request::OAuth, authentication
+          end
+        end
         builder.use Faraday::Request::Multipart
         builder.use Faraday::Request::UrlEncoded
         builder.use Faraday::Response::RaiseHttp4xx

--- a/spec/desk/api_spec.rb
+++ b/spec/desk/api_spec.rb
@@ -32,6 +32,7 @@ describe Desk::API do
         @configuration = {
           :consumer_key => 'CK',
           :consumer_secret => 'CS',
+          :domain => 'example.com',
           :oauth_token => 'OT',
           :oauth_token_secret => 'OS',
           :adapter => :typhoeus,

--- a/spec/desk/api_spec.rb
+++ b/spec/desk/api_spec.rb
@@ -30,6 +30,9 @@ describe Desk::API do
 
       before do
         @configuration = {
+          :auth_method => Desk::Authentication::Methods::BASIC,
+          :basic_auth_username => 'UN',
+          :basic_auth_password => 'PW',
           :consumer_key => 'CK',
           :consumer_secret => 'CS',
           :domain => 'example.com',

--- a/spec/desk_spec.rb
+++ b/spec/desk_spec.rb
@@ -77,7 +77,7 @@ describe Desk do
       Desk.version = "v4"
     end
 
-    it "should set the subdomain" do
+    it "should set the version" do
       Desk.version.should == "v4"
     end
 

--- a/spec/desk_spec.rb
+++ b/spec/desk_spec.rb
@@ -45,6 +45,22 @@ describe Desk do
     end
   end
 
+  describe ".auth_method" do
+    it "should return the default auth method" do
+      Desk.auth_method = Desk::Configuration::DEFAULT_AUTH_METHOD
+    end
+  end
+
+  describe ".auth_method=" do
+    it "should set the auth_method for all auth types" do
+      valid_methods = Desk::Authentication::Methods::ALL*5
+      valid_methods.each do |method|
+        Desk.auth_method = method
+        Desk.auth_method.should == method
+      end
+    end
+  end
+
   describe ".domain" do
     it "should return the default domain" do
       Desk.domain.should == Desk::Configuration::DEFAULT_DOMAIN

--- a/spec/desk_spec.rb
+++ b/spec/desk_spec.rb
@@ -45,6 +45,26 @@ describe Desk do
     end
   end
 
+  describe ".domain" do
+    it "should return the default domain" do
+      Desk.domain.should == Desk::Configuration::DEFAULT_DOMAIN
+    end
+  end
+
+  describe ".domain=" do
+    before do
+      Desk.domain = "example.org"
+    end
+
+    it "should set the domain" do
+      Desk.domain.should == "example.org"
+    end
+
+    it "should change the endpoint" do
+      Desk.endpoint.should == "https://#{Desk::Configuration::DEFAULT_SUBDOMAIN}.example.org/api/#{Desk::Configuration::DEFAULT_VERSION}/"
+    end
+  end
+
   describe ".subdomain=" do
     before do
       Desk.subdomain = "zencoder"
@@ -55,7 +75,7 @@ describe Desk do
     end
 
     it "should change the endpoint" do
-      Desk.endpoint.should == "https://zencoder.desk.com/api/#{Desk::Configuration::DEFAULT_VERSION}/"
+      Desk.endpoint.should == "https://zencoder.#{Desk::Configuration::DEFAULT_DOMAIN}/api/#{Desk::Configuration::DEFAULT_VERSION}/"
     end
   end
 


### PR DESCRIPTION
## Background

Desk supports [custom urls for business accounts](https://support.desk.com/customer/portal/articles/1548-using-your-own-domain-name) which creates some problems when it comes to OAuth and the current domain strategy. To my knowledge, some of these also support only basic authentication (username/password), or basic auth may be needed for prototyping.

## Solution

Allow for the customization of base domain name, but leave everything `desk.com` by default. Update the authentication and connection paths to support switching to Basic Mode.

## Extra Notes

af7850f has a simple test rewrite. Hopefully you don't mind me throwing that in there! 

There wasn't a lot of testing of connection parameters outside of the `desk_spec.rb` as far as I could tell. If I'm missing anything please let me know. 

I'm not as familiar with Yardoc, but I didn't appear to introduce any new issues there. (Coverage percentage net increased too)

This is my first "true" open source PR; thanks for providing a great project with which to get started! 