### PR TITLE
Get back the :type key for mashes in a forward-compatible way

### DIFF
--- a/desk.gemspec
+++ b/desk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('webmock', '~> 1.6')
   s.add_development_dependency('yard', '~> 0.6')
   s.add_runtime_dependency('json', '~> 1.7')  if RUBY_VERSION < '1.9'
-  s.add_runtime_dependency 'hashie', '3.4.1'
+  s.add_runtime_dependency 'hashie', '>= 3.4.2'
   s.add_runtime_dependency('faraday', '~> 0.9.0')
   s.add_runtime_dependency('faraday_middleware', '~> 0.9.0')
   s.add_runtime_dependency('jruby-openssl', '~> 0.7.2') if RUBY_PLATFORM == 'java'

--- a/lib/desk/deash.rb
+++ b/lib/desk/deash.rb
@@ -17,8 +17,7 @@ module Hashie
   end
 
   class Deash < Mash
-    # Object#type is deprecated
-    Mash.send :undef_method, :type
+    disable_warnings if respond_to?(:disable_warnings)
 
     def count
       if includes_key_chain?("raw._embedded.entries")

--- a/spec/desk/client/customer_spec.rb
+++ b/spec/desk/client/customer_spec.rb
@@ -16,7 +16,8 @@ describe Desk::Client do
 
     it_behaves_like "a create endpoint", {
       :first_name => "John",
-      :last_name => "Doe"
+      :last_name => "Doe",
+      :emails => [{:type => "work", :value => "joe.user@example.org"}]
     }
 
     it_behaves_like "an update endpoint", { :first_name => "Johnny" } do


### PR DESCRIPTION
Relates to #60 and #69.

The issue basically was that the `:type` method was forcefully removed. Hashie removed `:id` and `:type` methods just because they were not part of ruby base anymore, so they were treated as normal key accessors. Removing the method from `Mash` itself prevented the `:type` key from being used.

Also, a standard disabling of warning is added to avoid noise for clashing `class`, `first` and `entries` keys:
* https://github.com/intridea/hashie/pull/381 (version 3.5.0) — log attempts to override a built-in method and fails to do so. The accessors were not created anyway.
* https://github.com/intridea/hashie/pull/395 (version 3.5.2) — add the ability to silence those warning in subclasses.