### PR TITLE
Add license info to the gemspec.

### DIFF
--- a/desk.gemspec
+++ b/desk.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.homepage = 'https://github.com/zencoder/desk'
   s.name = 'desk'
+  s.license = 'MIT'
   s.platform = Gem::Platform::RUBY
   s.require_paths = ['lib']
   s.required_rubygems_version = Gem::Requirement.new('>= 1.3.6') if s.respond_to? :required_rubygems_version=


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gemspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.