### PR TITLE
Support for TLS v1.1

### DIFF
--- a/lib/desk/connection.rb
+++ b/lib/desk/connection.rb
@@ -13,7 +13,7 @@ module Desk
       options = {
         :headers => {'Accept' => "application/#{format}", 'User-Agent' => user_agent},
         :proxy => proxy,
-        :ssl => {:verify => false, :version => 'SSLv23'},
+        :ssl => {:verify => false, :version => 'TLSv1_1'},
         :url => api_endpoint,
         :request => {},
       }

--- a/spec/desk/api_spec.rb
+++ b/spec/desk/api_spec.rb
@@ -47,6 +47,7 @@ describe Desk::API do
           :use_max_requests => true,
           :user_agent => 'Custom User Agent',
           :version => "amazing",
+          :timeout => nil,
           :logger => double('logger')
         }
 


### PR DESCRIPTION
In order to be integrated with the new TLS version in DESK API we need to upgrade Faraday ssl version.

From Desk support:
> API integrations will cease to work if they are not compatible with TLS 1.1 or higher, including NET-based integrations that send requests to Desk. If you have a custom integration, the IT team that built / manages the integration should be able to help verify you are using TLS 1.1 or higher. 

Source: https://support.desk.com/customer/portal/articles/2914691?b_id=7112