### PR TITLE
Allow for newer versions of faraday

### DIFF
--- a/desk.gemspec
+++ b/desk.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('yard', '~> 0.6')
   s.add_runtime_dependency('json', '~> 1.7')  if RUBY_VERSION < '1.9'
   s.add_runtime_dependency 'hashie', '~> 3.4', '>= 3.4.2'
-  s.add_runtime_dependency('faraday', '~> 0.9.0')
-  s.add_runtime_dependency('faraday_middleware', '~> 0.9.0')
+  s.add_runtime_dependency('faraday', '~> 0.9')
+  s.add_runtime_dependency('faraday_middleware', '~> 0.9')
   s.add_runtime_dependency('jruby-openssl', '~> 0.7.2') if RUBY_PLATFORM == 'java'
   s.add_runtime_dependency('multi_json', '~> 1.6')
   s.add_runtime_dependency('multi_xml', '~> 0.5')


### PR DESCRIPTION
I know you requested no PRs with changes to the `gemspec`, but I wasn't sure how else to ask if this could be updated. It seems all the tests pass, and the `0.9` version of faraday is quite old and preventing me from updating to newer versions of other gems that I need to use in my project alongside desk.