### PR TITLE
Stops skipping SSL verification

### DIFF
--- a/lib/desk/connection.rb
+++ b/lib/desk/connection.rb
@@ -13,7 +13,7 @@ module Desk
       options = {
         :headers => {'Accept' => "application/#{format}", 'User-Agent' => user_agent},
         :proxy => proxy,
-        :ssl => {:verify => false, :version => 'TLSv1_1'},
+        :ssl => {:version => 'TLSv1_1'},
         :url => api_endpoint,
         :request => {},
       }


### PR DESCRIPTION
Skipping SSL verification is _very dangerous_.

As a reference: From the [Faraday Docs](https://github.com/lostisland/faraday/wiki/Setting-up-SSL-certificates):
```
This will eliminate the certificate verify failed error. However, it is strongly discouraged in production code as you're weakening the encryption process by using unchecked security certificates. This will open up your site to multiple types of cryptographic attacks.
```